### PR TITLE
Allow verifying Android projects with Gradle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM renovate/java
 
 USER root
 
-ENV GRADLE_VERSION=4.10.2
+ENV GRADLE_VERSION=5.0
 
 RUN	mkdir /opt/gradle && \
     curl -sL -o /tmp/gradle.zip https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,18 @@ RUN	mkdir /opt/gradle && \
     unzip -d /opt/gradle /tmp/gradle.zip && \
 	  rm /tmp/gradle.zip
 
+RUN curl -sL -o /opt/android-sdk.zip https://dl.google.com/android/android-sdk_r24.4.1-linux.tgz && \
+	cd /opt && \
+	tar -xf android-sdk.zip && \
+	cd /opt/android-sdk-linux/tools && \
+	while sleep 1; do echo y; done | ./android update sdk --no-ui && \
+	rm /opt/android-sdk.zip && \
+	cd /opt/android-sdk-linux/tools && \
+	while sleep 1; do echo y; done | ./android update sdk --all --no-ui --filter $(seq -s, 28) && \
+	chown -R ubuntu:ubuntu /opt/android-sdk-linux 
+
 ENV PATH=$PATH:/opt/gradle/gradle-$GRADLE_VERSION/bin
+ENV ANDROID_HOME=/opt/android-sdk-linux
 
 USER ubuntu
 


### PR DESCRIPTION
This pull request allows the Gradle Docker image to build Android projects. Since building Android projects is a pretty big use case for Gradle, this will allow Renovate to build a lot more projects. This PR was discussed in renovatebot/renovate#2707 already.

This would be a temporary compatibility fix before future improvements to the Gradle plugin. It comes at the cost of significant storage space for the container (9.33 GiB on my system) since all Android SDK versions are installed. As a result, this is really intended as a temporary fix and I won't feel bad if you don't want to merge this :)